### PR TITLE
Add #has_key? to RecursiveClosedStruct

### DIFF
--- a/lib/prawn_cocktail/utils/recursive_closed_struct.rb
+++ b/lib/prawn_cocktail/utils/recursive_closed_struct.rb
@@ -3,6 +3,10 @@ class RecursiveClosedStruct
     @hash = hash
   end
 
+  def has_key?(key)
+    @hash.has_key? key
+  end
+
   def method_missing(name, *)
     value = fetch(name)
     if value.is_a?(Hash)

--- a/spec/recursive_closed_struct_spec.rb
+++ b/spec/recursive_closed_struct_spec.rb
@@ -21,4 +21,21 @@ describe RecursiveClosedStruct do
     })
     assert_equal "four", subject.one.two.three
   end
+
+
+  it "lets a user check if the key exists without throwing an error" do
+    subject = RecursiveClosedStruct.new({
+      real: true
+    })
+
+    assert subject.has_key?(:real)
+  end
+
+  it "lets a user check if the key does not exist without throwing an error" do
+    subject = RecursiveClosedStruct.new({
+      real: true
+    })
+
+    refute subject.has_key?(:imaginary)
+  end
 end


### PR DESCRIPTION
Currently the only way to check to see if the struct has a value is to try and read it and catch the NoMethodError that gets thrown. This method makes it easier to do some logic on the presence or absence of a value.

I am not 100% sold on the method name `has_key?` and am happy to change it to something else.
