### PR TITLE
Non-destructivly merge multiple calls to meta

### DIFF
--- a/lib/prawn_cocktail/renderer.rb
+++ b/lib/prawn_cocktail/renderer.rb
@@ -5,13 +5,14 @@ require_relative "utils/recursive_closed_struct"
 module PrawnCocktail
   class Renderer
     def initialize(template_name, data, initializers)
+      @prawn_document_options = {}
       @template_name = template_name
       @data = data
       @initializers = initializers
     end
 
     def meta(opts)
-      @prawn_document_options = opts
+      @prawn_document_options.merge! opts
     end
 
     def content(&block)


### PR DESCRIPTION
This patch allows multiple calls to meta without obliterating the previous settings.

Personally I find

``` ruby
meta page_size: [612, 1008]
meta margin: 0
meta background: "/path/to/bg.jpg"
```

easier to read than

``` ruby
meta page_size: [612, 1008], margin: 0, background: "/path/to/bg.jpg"
```

This PR doesn't include any updates to the tests because I'm not entirely sure the best say to test this, short of using dependency injection to place a mock inside `PrawnCocktail::Renderer#prawn_document` and check to make sure the correct options where passed in. That's a bit more work than I was willing to put in without checking to make sure that would be accepted before hand.

Thoughts?
