### PR TITLE
CI: Use in-support Ruby versions only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
+cache: bundler
 rvm:
-  - 2.0.0
-  - 1.9.3
-  - rbx-19mode
+  - 2.7
+  - 2.6
+  - 2.5

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -65,5 +65,5 @@ def parse_geometry(pdf_data)
 end
 
 def expected_geometry(name)
-  Prawn::Document::PageGeometry::SIZES[name]
+  PDF::Core::PageGeometry::SIZES[name]
 end


### PR DESCRIPTION
This PR updates the Ruby versions in CI.

- cache bundler
- uses an updated constant in tests